### PR TITLE
Fix output of paginator_number tag being escaped in Django 1.9

### DIFF
--- a/suit/templatetags/suit_list.py
+++ b/suit/templatetags/suit_list.py
@@ -33,8 +33,9 @@ def paginator_number(cl, i):
     Generates an individual page index link in a paginated list.
     """
     if i == DOT:
-        return '<li class="disabled"><a href="#" onclick="return false;">..' \
-               '.</a></li>'
+        return mark_safe(
+                '<li class="disabled"><a href="#" onclick="return false;">..'
+                '.</a></li>')
     elif i == cl.page_num:
         return mark_safe(
             '<li class="active"><a href="">%d</a></li> ' % (i + 1))


### PR DESCRIPTION
From Django 1.9 release notes:
simple_tag now wraps tag output in conditional_escape
